### PR TITLE
Use context-dependent braces around hash parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ SpaceInsideBlockBraces:
 
 SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+  
+BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
 
 StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
Prevent Rubocop from overzealous hash bracket removal. Sometimes I have an array of Hashes. Rubocop can understand that with this setting.
