### PR TITLE
Be strict with Rails dates for timezone happiness

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ BracesAroundHashParameters:
 StringLiterals:
   EnforcedStyle: double_quotes
 
+Rails/Date:
+  EnforcedStyle: strict
+
 #################
 # Disabled cops #
 #################


### PR DESCRIPTION
We want to be told if we're using `Date.today` instead of `Date.current`
