### PR TITLE
Enforce outdenting public/private/protected

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,10 @@ BracesAroundHashParameters:
 StringLiterals:
   EnforcedStyle: double_quotes
 
+# See: http://collectiveidea.com/blog/archives/2016/09/09/my-ruby-epiphany/
+Style/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
 #################
 # Disabled cops #
 #################


### PR DESCRIPTION
After I realize how the parser really sees these, I think we should change how we do them
http://collectiveidea.com/blog/archives/2016/09/09/my-ruby-epiphany/

The funny thing is I don't actually like this. I've been a fan of indenting, but I've come to realize I'm doing it wrong. I don't expect this PR to be without controversy.

An alternative that I hadn't thought about was mentioned in the comments of my post: 

``` ruby
class Foo

  private def some_method
    ...
  end
end
```

This is really using the syntax `private :some_method` because in Ruby 2.1+, defining a method returns a symbol. (more here: https://www.sitepoint.com/look-ruby-2-1/)

This is meant to start the discussion. What do we think?
