### PR TITLE
Always use spaces inside curly brackets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,10 +38,10 @@ SignalException:
   EnforcedStyle: only_raise
 
 SpaceInsideBlockBraces:
-  SpaceBeforeBlockParameters: false
+  SpaceBeforeBlockParameters: true
 
 SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
+  EnforcedStyle: space
 
 BracesAroundHashParameters:
   EnforcedStyle: context_dependent


### PR DESCRIPTION
Nearly every project I've been on uses spaces inside curly braces
regardless of context.

Before:

```ruby
foos.each {|foo| foo.bar }
{foo: "bar", baz: "what comes after baz?"}
```

After:

```ruby
foos.each { |foo| foo.bar }
{ foo: "bar", baz: "what comes after baz?" }
```

For blocks, we use a space after `do`, so why wouldn't we
use a space after an opening bracket instead?

For hashes, I don't know why, but I personally find the spaces
comforting. Curly brackets demand personal space. I think it's
because there's a lot more syntax happening inside a hash literal
than you'll usually see  inside arrays and method arguments, so
the extra spaces give each key/value entry a bit more space to
clearly stand out.