### PR TITLE
Reduce max line length to 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ IfUnlessModifier:
   MaxLineLength: 75
 
 LineLength:
-  Max: 200
+  Max: 120
 
 SignalException:
   EnforcedStyle: only_raise


### PR DESCRIPTION
200 seems like a really high number. I think there are a lot of reasons
to go even shorter than 120, to either 100 or 80, but this is at least
an improvement.