### PR TITLE
Enforce square brackets for %w and %i

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,13 @@ Style/Lambda:
 Style/NegatedIf:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%w": "[]"
+    "%W": "[]"
+    "%i": "[]"
+    "%I": "[]"
+
 Style/Semicolon:
   Enabled: false
 


### PR DESCRIPTION
When using `%w` or `%i`, it makes more sense to use `[]` instead of `()`
since we're defining an array.`%w[foo bar]` is more consistent with
how we read arrays than `%w(foo bar)`. This is actually now the rubocop
default, but I think it's still worth it to define it here for clarity.

This is also in line with the ruby style guide:
https://github.com/bbatsov/ruby-style-guide#percent-literal-braces