### PR TITLE
Bring config up to speed with new rubocop version 0.52.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,9 +31,6 @@ Style/CollectionMethods:
 EndAlignment:
   AlignWith: variable
 
-IfUnlessModifier:
-  MaxLineLength: 75
-
 LineLength:
   Max: 120
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Style/CollectionMethods:
 
 # Align ends correctly.
 EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 LineLength:
   Max: 120


### PR DESCRIPTION
A couple of renamed or removed configuration options.