### PR TITLE
[DISCUSS] Disable cop Capybara/FeatureMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,3 +131,7 @@ RSpec/MultipleExpectations:
 # enforces rules about how many nested `describe` blocks are allowed
 RSpec/NestedGroups:
   Enabled: false
+
+# enforces rules about using `it` or `describe` block methods instead of `feature` or `scenario`
+Capybara/FeatureMethods:
+  Enabled: false


### PR DESCRIPTION
This cop enforces using `it`, `xit`, `describe`, etc block methods
rather than `feature`, `scenario`, etc in feature specs.

Checks for consistent method usage in feature specs.

```ruby
@example
  # bad
  feature 'User logs in' do
    given(:user) { User.new }

    background do
      visit new_session_path
    end

    scenario 'with OAuth' do
      # ...
    end
  end

  # good
  describe 'User logs in' do
    let(:user) { User.new }

    before do
      visit new_session_path
    end

    it 'with OAuth' do
      # ...
    end
  end
```

Disable to allow developer to choose which block method they use in features.