### PR TITLE
[DISCUSS] Enforce `expanded` for cop Style/EmptyMethod

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,9 @@ Style/CollectionMethods:
     find: 'detect'
     each_with_index: 'each.with_index'
 
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 # Align ends correctly.
 EndAlignment:
   EnforcedStyleAlignWith: variable
@@ -68,9 +71,6 @@ Style/Documentation:
   Enabled: false
 
 Style/EachWithObject:
-  Enabled: false
-
-Style/EmptyMethod:
   Enabled: false
 
 Style/FormatString:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,9 @@ Style/Documentation:
 Style/EachWithObject:
   Enabled: false
 
+Style/EmptyMethod:
+  Enabled: false
+
 Style/FormatString:
   Enabled: false
 


### PR DESCRIPTION
This cop enforces compressing empty methods to a single line.

```
@example
  # bad
  def edit
  end

  # good
  def edit; end
```

Disabling to allow empty methods to maintain the same format of
non-empty methods. Produces cleaner diffs, especially when adding
content to the empty method.

We encountered this in one of our projects and after some brief discussion, we wanted to propose this as a universal disable for [i] projects. 