### PR TITLE
Fixes Style/TrailingCommaInLiteral removal warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,12 +99,6 @@ Style/Semicolon:
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
 Style/WordArray:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,7 +99,10 @@ Style/Semicolon:
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 Style/WordArray:


### PR DESCRIPTION
* Quiets errors when running with rubocop v0.59.2